### PR TITLE
[Feat] front 모임장소 페이지 생성 & 카카오 api 활용해서 지도 생성 & 검색 로직 구현

### DIFF
--- a/app/place/page.tsx
+++ b/app/place/page.tsx
@@ -1,0 +1,631 @@
+"use client"
+
+import React, { useEffect, useRef, useState } from "react"
+
+declare global {
+  interface Window {
+    kakao: any
+  }
+}
+
+const KAKAO_JAVASCRIPT_KEY = "c52623cf77688344fca417685b697139"
+const KAKAO_REST_API_KEY = "be68f1d6bafcf4656ae48dc9e2d7680f"
+
+export default function PlacePage() {
+  const mapRef = useRef<HTMLDivElement>(null)
+  // 입력창 하나로 통합
+  const [searchInput, setSearchInput] = useState("")
+  const [suggestions, setSuggestions] = useState<any[]>([])
+  const [showSuggestions, setShowSuggestions] = useState(false)
+  const [highlighted, setHighlighted] = useState(-1)
+  const [isComposing, setIsComposing] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+  const [inputError, setInputError] = useState("")
+  const [placeMarkers, setPlaceMarkers] = useState<any[]>([])
+  const [selectedPlace, setSelectedPlace] = useState<any>(null)
+  const [isLocationMoved, setIsLocationMoved] = useState(false)
+  const [justMovedOnly, setJustMovedOnly] = useState(false)
+  const mapInstance = useRef<any>(null)
+  const infoWindowInstance = useRef<any>(null)
+  const [isMapReady, setIsMapReady] = useState(false)
+  const [centerLatLng, setCenterLatLng] = useState<{lat: number, lng: number} | null>(null)
+  const [lastMovedPlaceName, setLastMovedPlaceName] = useState("")
+  // Polygon 상태 관리
+  const [regionPolygon, setRegionPolygon] = useState<any>(null)
+
+  // 지도 로딩
+  useEffect(() => {
+    const scriptId = "kakao-map-script"
+    if (!document.getElementById(scriptId)) {
+      const script = document.createElement("script")
+      script.id = scriptId
+      script.src = `//dapi.kakao.com/v2/maps/sdk.js?appkey=${KAKAO_JAVASCRIPT_KEY}&autoload=false&libraries=services`
+      script.async = true
+      document.head.appendChild(script)
+      script.onload = initMap
+    } else {
+      if (window.kakao && window.kakao.maps) {
+        window.kakao.maps.load(initMap)
+      }
+    }
+    function initMap() {
+      window.kakao.maps.load(() => {
+        let lat = 37.5665
+        let lng = 126.9780
+        if (navigator.geolocation) {
+          navigator.geolocation.getCurrentPosition(
+            (position) => {
+              lat = position.coords.latitude
+              lng = position.coords.longitude
+              createMap(lat, lng)
+            },
+            () => {
+              createMap(lat, lng)
+            }
+          )
+        } else {
+          createMap(lat, lng)
+        }
+      })
+    }
+    function createMap(lat: number, lng: number) {
+      if (!mapRef.current) return
+      const map = new window.kakao.maps.Map(mapRef.current, {
+        center: new window.kakao.maps.LatLng(lat, lng),
+        level: 3,
+      })
+      mapInstance.current = map
+      setIsMapReady(!!window.kakao.maps.services)
+      // 지도 이동(드래그/줌 등) 끝날 때마다 centerLatLng 갱신
+      window.kakao.maps.event.addListener(map, 'dragend', () => {
+        const center = map.getCenter();
+        setCenterLatLng({ lat: center.getLat(), lng: center.getLng() });
+      });
+      window.kakao.maps.event.addListener(map, 'zoom_changed', () => {
+        const center = map.getCenter();
+        setCenterLatLng({ lat: center.getLat(), lng: center.getLng() });
+      });
+    }
+  }, [])
+
+  // 자동완성: 장소명 부분만
+  useEffect(() => {
+    if (!isMapReady) return
+    const controller = new AbortController()
+    const [locationPart] = searchInput.trim().split(/\s+/)
+    if (!locationPart || locationPart.length < 2) {
+      setSuggestions([])
+      setShowSuggestions(false)
+      return
+    }
+    const timeout = setTimeout(() => {
+      fetch(`https://dapi.kakao.com/v2/local/search/keyword.json?query=${encodeURIComponent(locationPart)}`, {
+        headers: { Authorization: `KakaoAK ${KAKAO_REST_API_KEY}` },
+        signal: controller.signal,
+      })
+        .then(res => res.json())
+        .then(data => {
+          if (data.documents && data.documents.length > 0) {
+            setSuggestions(data.documents.slice(0, 8))
+            setShowSuggestions(true)
+          } else {
+            setSuggestions([])
+            setShowSuggestions(false)
+          }
+        })
+        .catch(() => {})
+    }, 200)
+    return () => {
+      clearTimeout(timeout)
+      controller.abort()
+    }
+  }, [searchInput, isMapReady])
+
+  // 지역명 판별 함수 (간단 버전, 실제 서비스에서는 더 정교하게 가능)
+  function isRegionName(keyword: string) {
+    const trimmed = keyword.trim();
+    if (trimmed.endsWith('역')) return false; // '역'으로 끝나면 지역명 아님
+    return /[시도군구읍면동]$/.test(trimmed) || ["서울", "부산", "대구", "인천", "광주", "대전", "울산", "세종", "경기", "강원", "충북", "충남", "전북", "전남", "경북", "경남", "제주"].some(r => trimmed.startsWith(r));
+  }
+
+  // 통합 검색 실행
+  const handleUnifiedSearch = async (input?: string, suggestionPlace?: any) => {
+    const value = (input ?? searchInput).trim()
+    if (value.length < 2) {
+      setInputError("2글자 이상 입력해 주세요.")
+      return
+    }
+    setInputError("")
+    // 지역명만 입력(공백 없는 한 단어 또는 시/도/구/군/읍/면/동 등으로 끝나는 단어)일 때만 Polygon 표시/중심 이동
+    const isOnlyRegion = isRegionName(value) && value.split(/\s+/).length === 1;
+    if (isOnlyRegion) {
+      // 기존 마커/인포윈도우/검색 결과 제거
+      setPlaceMarkers([])
+      setSelectedPlace(null)
+      setInputError("")
+      setLastMovedPlaceName("")
+      // 기존 Polygon 제거
+      if (regionPolygon) {
+        regionPolygon.setMap(null)
+        setRegionPolygon(null)
+      }
+      // Polygon 표시 또는 중심 이동
+      if (window.kakao && window.kakao.maps && window.kakao.maps.services) {
+        const geocoder = new window.kakao.maps.services.Geocoder();
+        geocoder.addressSearch(value, (result: any[], status: string) => {
+          if (status === window.kakao.maps.services.Status.OK && result.length > 0) {
+            const lat = parseFloat(result[0].y);
+            const lng = parseFloat(result[0].x);
+            // 행정구역 경계 검색 (Polygon)
+            if (window.kakao.maps.services && window.kakao.maps.services.Polygon) {
+              // Polygon API가 있으면 사용 (최신 SDK)
+              const polygonService = new window.kakao.maps.services.Polygon();
+              polygonService.search(value, (polygonResult: any[], polygonStatus: string) => {
+                if (polygonStatus === window.kakao.maps.services.Status.OK && polygonResult.length > 0) {
+                  const path = polygonResult[0].polygon[0].map((coord: any) => new window.kakao.maps.LatLng(coord.y, coord.x));
+                  const polygon = new window.kakao.maps.Polygon({
+                    path,
+                    strokeWeight: 3,
+                    strokeColor: '#FF00FF',
+                    fillColor: '#FF00FF',
+                    fillOpacity: 0.15,
+                  });
+                  polygon.setMap(mapInstance.current);
+                  setRegionPolygon(polygon);
+                  // bounds 맞추기
+                  const bounds = new window.kakao.maps.LatLngBounds();
+                  path.forEach((latlng: any) => bounds.extend(latlng));
+                  mapInstance.current.setBounds(bounds);
+                } else {
+                  // Polygon API 실패 시 중심 좌표만 이동
+                  mapInstance.current.setCenter(new window.kakao.maps.LatLng(lat, lng));
+                  setInputError("이 지역의 경계는 카카오 지도에서 지원하지 않습니다.");
+                }
+              });
+            } else {
+              // Polygon API가 없으면 중심 좌표만 이동 + 안내
+              mapInstance.current.setCenter(new window.kakao.maps.LatLng(lat, lng));
+              setInputError("이 지역의 경계는 카카오 지도에서 지원하지 않습니다.");
+            }
+          } else {
+            setInputError("지역을 찾을 수 없습니다.");
+          }
+        });
+      }
+      return;
+    }
+    // 장소명, 카테고리 분리
+    const parts = value.split(/\s+/)
+    // 1. 장소명+카테고리 (2단어 이상)
+    if (parts.length >= 2) {
+      // 1) 전체 입력값으로 장소 이동 시도
+      let lat: number | null = null, lng: number | null = null
+      let found = false
+      const fullQuery = value
+      const resFull = await fetch(`https://dapi.kakao.com/v2/local/search/keyword.json?query=${encodeURIComponent(fullQuery)}`, {
+        headers: { Authorization: `KakaoAK ${KAKAO_REST_API_KEY}` },
+      })
+      const dataFull = await resFull.json()
+      if (dataFull.documents && dataFull.documents.length > 0) {
+        lat = parseFloat(dataFull.documents[0].y)
+        lng = parseFloat(dataFull.documents[0].x)
+        found = true
+      }
+      if (found && lat !== null && lng !== null && mapInstance.current) {
+        const moveLatLng = new window.kakao.maps.LatLng(lat, lng)
+        mapInstance.current.setCenter(moveLatLng)
+        setCenterLatLng({ lat, lng })
+        setIsLocationMoved(true)
+        setPlaceMarkers([])
+        setSelectedPlace(null)
+        setInputError("")
+        setJustMovedOnly(true)
+        // setCenter 후 카테고리로 주변 검색
+        // 카테고리로 주변 검색
+        const categoryPart = suggestionPlace ? parts.slice(1).join(" ") : parts.slice(1).join(" ")
+        if (categoryPart.length >= 2) {
+          // setTimeout으로 setCenter 이후에 searchNearbyPlaces가 실행되도록 보장
+          setTimeout(() => {
+            if (lat !== null && lng !== null) {
+              searchNearbyPlaces(categoryPart, true, { lat, lng })
+            }
+          }, 200)
+        }
+        return;
+      }
+      // 2) 기존 로직: 첫 단어로 이동, 두 번째 단어로 주변 검색
+      const locationPart = suggestionPlace ? suggestionPlace.place_name : parts[0]
+      const categoryPart = suggestionPlace ? parts.slice(1).join(" ") : parts.slice(1).join(" ")
+      lat = null; lng = null;
+      if (suggestionPlace) {
+        lat = parseFloat(suggestionPlace.y)
+        lng = parseFloat(suggestionPlace.x)
+      } else if (suggestions.length > 0) {
+        const exact = suggestions.find(s => s.place_name === locationPart)
+        if (exact) {
+          lat = parseFloat(exact.y)
+          lng = parseFloat(exact.x)
+        } else {
+          lat = parseFloat(suggestions[0].y)
+          lng = parseFloat(suggestions[0].x)
+        }
+      } else {
+        const res = await fetch(`https://dapi.kakao.com/v2/local/search/keyword.json?query=${encodeURIComponent(locationPart)}`, {
+          headers: { Authorization: `KakaoAK ${KAKAO_REST_API_KEY}` },
+        })
+        const data = await res.json()
+        if (data.documents && data.documents.length > 0) {
+          lat = parseFloat(data.documents[0].y)
+          lng = parseFloat(data.documents[0].x)
+        }
+      }
+      if (lat && lng && mapInstance.current) {
+        const moveLatLng = new window.kakao.maps.LatLng(lat, lng)
+        mapInstance.current.setCenter(moveLatLng)
+        setCenterLatLng({ lat, lng })
+        setIsLocationMoved(true)
+        setPlaceMarkers([])
+        setSelectedPlace(null)
+        // 카테고리로 주변 검색
+        if (categoryPart.length >= 2) searchNearbyPlaces(categoryPart, true, { lat, lng })
+      }
+      return;
+    } else if (parts.length === 1) {
+      // 장소명만 입력: 지도만 이동, 주변 장소 검색 X, 마커 생성 X
+      const locationPart = suggestionPlace ? suggestionPlace.place_name : parts[0]
+      let lat: number | null = null, lng: number | null = null
+      if (suggestionPlace) {
+        lat = parseFloat(suggestionPlace.y)
+        lng = parseFloat(suggestionPlace.x)
+      } else if (suggestions.length > 0) {
+        const exact = suggestions.find(s => s.place_name === locationPart)
+        if (exact) {
+          lat = parseFloat(exact.y)
+          lng = parseFloat(exact.x)
+        } else {
+          lat = parseFloat(suggestions[0].y)
+          lng = parseFloat(suggestions[0].x)
+        }
+      } else {
+        const res = await fetch(`https://dapi.kakao.com/v2/local/search/keyword.json?query=${encodeURIComponent(locationPart)}`, {
+          headers: { Authorization: `KakaoAK ${KAKAO_REST_API_KEY}` },
+        })
+        const data = await res.json()
+        if (data.documents && data.documents.length > 0) {
+          lat = parseFloat(data.documents[0].y)
+          lng = parseFloat(data.documents[0].x)
+        }
+      }
+      if (lat && lng && mapInstance.current) {
+        // 카테고리(공백 없는 한 단어)가 아니라 장소명만 입력일 때만 setCenter
+        if (!isCategoryKeyword(locationPart)) {
+          const moveLatLng = new window.kakao.maps.LatLng(lat, lng)
+          mapInstance.current.setCenter(moveLatLng)
+          setCenterLatLng({ lat, lng })
+          setIsLocationMoved(true)
+          // 기존 마커/오류 제거
+          setPlaceMarkers([])
+          setSelectedPlace(null)
+          setInputError("")
+          setLastMovedPlaceName(locationPart)
+        }
+        // 카테고리만 입력 시에는 setCenter 호출하지 않음
+      }
+      return;
+    }
+  }
+
+  // 카테고리 키워드 판별 함수
+  function isCategoryKeyword(keyword: string) {
+    const categories = ["음식점", "카페", "편의점", "주차장", "주유소", "약국", "마트", "은행", "술집"]
+    return categories.includes(keyword.trim())
+  }
+
+  // 추천 클릭
+  const handleSuggestionClick = (place: any) => {
+    handleUnifiedSearch(searchInput, place)
+    setShowSuggestions(false)
+    setHighlighted(-1)
+  }
+
+  // 엔터/키보드
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" && !isComposing) {
+      if (showSuggestions && suggestions.length > 0) {
+        const idx = highlighted === -1 ? 0 : highlighted;
+        setShowSuggestions(false);
+        setHighlighted(-1);
+        (e.target as HTMLInputElement).blur();
+        // 정확히 일치하는 장소 우선
+        const [locationPart] = searchInput.trim().split(/\s+/)
+        const exact = suggestions.find(s => s.place_name === locationPart)
+        if (exact) {
+          handleUnifiedSearch(searchInput, exact)
+        } else {
+          handleUnifiedSearch(searchInput, suggestions[idx])
+        }
+        return;
+      }
+      if (showSuggestions && highlighted >= 0 && suggestions[highlighted]) {
+        handleUnifiedSearch(searchInput, suggestions[highlighted])
+      } else if (showSuggestions && suggestions.length > 0) {
+        // 입력값과 정확히 일치하는 지하철역 우선
+        const [locationPart] = searchInput.trim().split(/\s+/)
+        const exactSubway = suggestions.find(s => s.place_name === locationPart && s.category_name && s.category_name.includes("지하철역"))
+        if (exactSubway) {
+          handleUnifiedSearch(searchInput, exactSubway)
+        } else {
+          const exact = suggestions.find(s => s.place_name === locationPart)
+          if (exact) {
+            handleUnifiedSearch(searchInput, exact)
+          } else {
+            handleUnifiedSearch(searchInput, suggestions[0])
+          }
+        }
+      } else {
+        handleUnifiedSearch()
+      }
+      setShowSuggestions(false)
+      setHighlighted(-1)
+    } else if (e.key === "ArrowDown") {
+      setHighlighted(h => Math.min(h + 1, suggestions.length - 1))
+    } else if (e.key === "ArrowUp") {
+      setHighlighted(h => Math.max(h - 1, 0))
+    } else if (e.key === "Escape") {
+      setShowSuggestions(false)
+      setHighlighted(-1)
+    }
+  }
+
+  // 주변 장소 검색 (지도 중심 기준, 장소 이동 후에만 마커 표시)
+  const searchNearbyPlaces = async (
+    keyword: string,
+    adjustBounds = false,
+    customCenter?: {lat: number, lng: number} | null,
+    preventMapMove: boolean = false
+  ) => {
+    if (!window.kakao || !window.kakao.maps || !keyword.trim() || !isMapReady || !mapInstance.current || isLoading) return
+    if (keyword.trim().length < 2) {
+      setInputError("2글자 이상 입력해 주세요.")
+      return
+    } else {
+      setInputError("")
+    }
+    setIsLoading(true)
+    if (placeMarkers.length > 0) {
+      placeMarkers.forEach((m: any) => m.marker.setMap(null))
+    }
+    setPlaceMarkers([])
+    setSelectedPlace(null)
+    let allPlaces: any[] = []
+    // 카테고리 코드 분기
+    let categoryCode = ""
+    const trimmed = keyword.trim()
+    if (trimmed === "음식점") categoryCode = "FD6"
+    if (trimmed === "카페") categoryCode = "CE7"
+    if (trimmed === "편의점") categoryCode = "CS2"
+    if (trimmed === "주차장") categoryCode = "PK6"
+    if (trimmed === "주유소") categoryCode = "OL7"
+    if (trimmed === "약국") categoryCode = "PM9"
+    if (trimmed === "마트") categoryCode = "MT1"
+    if (trimmed === "은행") categoryCode = "BK9"
+    const isBar = trimmed === "술집"
+    if (isBar) categoryCode = "FD6"
+    // 중심 좌표 결정
+    let lat: number, lng: number
+    if (customCenter && typeof customCenter.lat === 'number' && typeof customCenter.lng === 'number') {
+      lat = customCenter.lat
+      lng = customCenter.lng
+    } else if (mapInstance.current) {
+      const center = mapInstance.current.getCenter()
+      lat = center.getLat()
+      lng = center.getLng()
+    } else {
+      alert('지도의 중심 좌표를 알 수 없습니다.')
+      setIsLoading(false)
+      return
+    }
+    // 거리 계산 함수
+    function getDistance(lat1: number, lng1: number, lat2: number, lng2: number) {
+      const R = 6371e3; // meters
+      const φ1 = lat1 * Math.PI/180;
+      const φ2 = lat2 * Math.PI/180;
+      const Δφ = (lat2-lat1) * Math.PI/180;
+      const Δλ = (lng2-lng1) * Math.PI/180;
+      const a = Math.sin(Δφ/2) * Math.sin(Δφ/2) +
+                Math.cos(φ1) * Math.cos(φ2) *
+                Math.sin(Δλ/2) * Math.sin(Δλ/2);
+      const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
+      return R * c;
+    }
+    try {
+      for (let page = 1; page <= 3; page++) {
+        const url =
+          `https://dapi.kakao.com/v2/local/search/keyword.json?query=${encodeURIComponent(keyword)}&x=${lng}&y=${lat}&radius=1000&page=${page}` +
+          (categoryCode ? `&category_group_code=${categoryCode}` : "")
+        const res = await fetch(url, {
+          headers: { Authorization: `KakaoAK ${KAKAO_REST_API_KEY}` },
+        })
+        const data = await res.json()
+        if (data.documents && data.documents.length > 0) {
+          allPlaces = allPlaces.concat(data.documents)
+          if (!data.meta.is_end) continue
+          else break
+        } else {
+          break
+        }
+      }
+      let uniquePlaces = allPlaces.filter((place, idx, arr) =>
+        arr.findIndex(p => p.x === place.x && p.y === place.y) === idx
+      )
+      // 중심에서 1km 이내만 남김
+      uniquePlaces = uniquePlaces.filter(
+        (place: any) => getDistance(lat, lng, parseFloat(place.y), parseFloat(place.x)) <= 1000
+      )
+      if (isBar) {
+        uniquePlaces = uniquePlaces.filter(
+          (place: any) =>
+            (place.place_name && /술집|호프|바/i.test(place.place_name)) ||
+            (place.category_name && /술집|호프|바/i.test(place.category_name))
+        )
+      }
+      if (uniquePlaces.length > 0) {
+        const markers = uniquePlaces.map((place: any) => {
+          const marker = new window.kakao.maps.Marker({
+            map: mapInstance.current,
+            position: new window.kakao.maps.LatLng(parseFloat(place.y), parseFloat(place.x)),
+            title: place.place_name,
+          })
+          window.kakao.maps.event.addListener(marker, "click", () => {
+            setSelectedPlace(place)
+            mapInstance.current.setCenter(new window.kakao.maps.LatLng(parseFloat(place.y), parseFloat(place.x)))
+          })
+          return { marker, place }
+        })
+        setPlaceMarkers(markers)
+        if (!preventMapMove) {
+          // setBounds는 마커가 2개 이상이고 모두 1km 이내일 때만 사용
+          if (markers.length > 1) {
+            // 모든 마커가 중심에서 1km 이내인지 확인
+            const allWithin1km = markers.every((m: any) =>
+              getDistance(lat, lng, m.marker.getPosition().getLat(), m.marker.getPosition().getLng()) <= 1000
+            )
+            if (adjustBounds && allWithin1km) {
+              const bounds = new window.kakao.maps.LatLngBounds()
+              markers.forEach((m: any) => bounds.extend(m.marker.getPosition()))
+              mapInstance.current.setBounds(bounds)
+            } else {
+              // 중심 좌표로만 이동
+              mapInstance.current.setCenter(new window.kakao.maps.LatLng(lat, lng))
+            }
+          } else if (markers.length === 1) {
+            // 마커가 1개면 중심 좌표로 이동
+            mapInstance.current.setCenter(new window.kakao.maps.LatLng(lat, lng))
+          }
+        }
+      } else {
+        alert("주변 장소를 찾을 수 없습니다.")
+      }
+    } catch (e) {
+      alert("주변 장소 검색 중 오류가 발생했습니다.")
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  // 입력값이 바뀔 때마다 장소 이동 없이 주변 장소만 검색(카테고리만 입력 시)
+  useEffect(() => {
+    if (showSuggestions) return; // 추천 리스트가 보이면 주변 장소 검색 실행 X
+    if (justMovedOnly) { setJustMovedOnly(false); return; }
+    if (!isComposing && isMapReady && mapInstance.current && searchInput.trim().length >= 2 && !isLoading) {
+      const parts = searchInput.trim().split(/\s+/);
+      // 카테고리만 입력(공백 없는 한 단어, 카테고리 키워드)일 때만
+      if (parts.length === 1 && isCategoryKeyword(parts[0])) {
+        const center = mapInstance.current.getCenter();
+        searchNearbyPlaces(parts[0], true, { lat: center.getLat(), lng: center.getLng() }, true);
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchInput, isComposing, isMapReady, showSuggestions, justMovedOnly]);
+
+  // 장소 이동 시 마커 숨김, 다시 돌아오면 마커 표시
+  useEffect(() => {
+    if (!isLocationMoved && placeMarkers.length > 0) {
+      placeMarkers.forEach((m: any) => m.marker.setMap(null))
+      setPlaceMarkers([])
+      setSelectedPlace(null)
+    }
+  }, [isLocationMoved])
+
+  // 인포윈도우 표시 (기존과 동일)
+  useEffect(() => {
+    if (!window.kakao || !window.kakao.maps || !selectedPlace) return
+    // 기존 인포윈도우 닫기
+    if (infoWindowInstance.current) {
+      infoWindowInstance.current.close()
+      infoWindowInstance.current = null
+    }
+    let content = `<div style='padding:18px 24px 18px 18px; min-width:240px; max-width:340px; font-size:17px; color:#222; font-weight:600;'>`
+    content += selectedPlace.place_name ? `<div style='font-size:18px; font-weight:700;'>${selectedPlace.place_name}</div>` : ""
+    content += selectedPlace.road_address_name ? `<div style='font-size:15px; color:#444; margin-top:6px;'>${selectedPlace.road_address_name}</div>` : ""
+    content += selectedPlace.address_name && !selectedPlace.road_address_name ? `<div style='font-size:15px; color:#444; margin-top:6px;'>${selectedPlace.address_name}</div>` : ""
+    if (selectedPlace.phone) {
+      content += `<div style='font-size:14px; color:#666; margin-top:6px;'>전화번호: ${selectedPlace.phone}</div>`
+    }
+    if (selectedPlace.opening_hours) {
+      content += `<div style='font-size:14px; color:#666; margin-top:6px;'>영업시간: ${selectedPlace.opening_hours}</div>`
+    } else if (selectedPlace.bizhour_info) {
+      content += `<div style='font-size:14px; color:#666; margin-top:6px;'>영업시간: ${selectedPlace.bizhour_info}</div>`
+    } else if (selectedPlace.hours) {
+      content += `<div style='font-size:14px; color:#666; margin-top:6px;'>영업시간: ${selectedPlace.hours}</div>`
+    }
+    content += `</div>`
+    const iw = new window.kakao.maps.InfoWindow({
+      content,
+      removable: true,
+    })
+    // 해당 마커 위에 표시
+    const markerObj = placeMarkers.find(m => m.place.id === selectedPlace.id)
+    if (markerObj) {
+      iw.open(mapInstance.current, markerObj.marker)
+      infoWindowInstance.current = iw
+    }
+  }, [selectedPlace])
+
+  // Polygon 상태 정리: 장소/카테고리 검색 시 기존 Polygon 제거
+  useEffect(() => {
+    if (regionPolygon && (searchInput.trim().length === 0 || (!isRegionName(searchInput.trim()) && searchInput.trim().length > 0))) {
+      regionPolygon.setMap(null);
+      setRegionPolygon(null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchInput])
+
+  return (
+    <div className="container mx-auto px-4 py-8 relative">
+      <h1 className="text-3xl font-bold mb-4">모임장소</h1>
+      {/* 통합 입력창 + 추천 */}
+      <div className="absolute top-[90px] left-8 z-20 w-full max-w-xs">
+        <div className="relative mb-3">
+          <input
+            type="text"
+            className="w-full rounded-xl bg-black/80 text-white placeholder-gray-300 border-none outline-none px-4 py-3 shadow-lg text-base font-semibold focus:ring-2 focus:ring-blue-500"
+            placeholder={isMapReady ? "장소명 또는 '장소명 카테고리'를 입력하세요 (예: 강남역 카페)" : "지도를 불러오는 중입니다..."}
+            value={searchInput}
+            onChange={e => { setSearchInput(e.target.value); setShowSuggestions(true); setHighlighted(-1); setInputError("") }}
+            autoComplete="off"
+            disabled={!isMapReady}
+            onKeyDown={handleKeyDown}
+            onCompositionStart={() => setIsComposing(true)}
+            onCompositionEnd={e => {
+              setIsComposing(false)
+              setSearchInput(e.currentTarget.value)
+            }}
+          />
+          {/* 추천 리스트 드롭다운 */}
+          {showSuggestions && suggestions.length > 0 && isMapReady && (
+            <ul className="absolute left-0 right-0 mt-2 bg-black/90 rounded-xl shadow-xl border border-gray-700 overflow-hidden max-h-60 z-20">
+              {suggestions.map((s, i) => (
+                <li
+                  key={s.id || s.place_name + i}
+                  className={`px-4 py-2 cursor-pointer text-white hover:bg-blue-700 transition text-base ${highlighted === i ? "bg-blue-700" : ""}`}
+                  onMouseDown={() => handleSuggestionClick(s)}
+                  onMouseEnter={() => setHighlighted(i)}
+                >
+                  <span className="font-semibold">{s.place_name}</span>
+                  {s.road_address_name && (
+                    <span className="ml-2 text-xs text-gray-300">{s.road_address_name}</span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+          {inputError && (
+            <div className="text-red-400 text-sm mt-2 ml-1">{inputError}</div>
+          )}
+        </div>
+      </div>
+      <div ref={mapRef} className="w-full h-[70vh] mt-16 rounded shadow border relative z-0" />
+    </div>
+  )
+} 

--- a/app/questions/create/page.tsx
+++ b/app/questions/create/page.tsx
@@ -15,7 +15,7 @@ import { Badge } from "@/components/ui/badge"
 import FileUpload from "@/components/file-upload"
 import { Checkbox } from "@/components/ui/checkbox"
 import { api } from "@/lib/api-client"
-import { AVAILABLE_TECH_TAGS } from "@/lib/constants/tech-tags"
+
 
 export default function CreateQuestionPage() {
   const router = useRouter()
@@ -28,7 +28,9 @@ export default function CreateQuestionPage() {
   const [uploadedImages, setUploadedImages] = useState<File[]>([])
 
   // 미리 정의된 태그 목록 추가
-  const predefinedTags = AVAILABLE_TECH_TAGS
+  const predefinedTags = [
+    "Java", "JavaScript", "TypeScript", "React", "Next.js", "Vue.js", "Angular", "Node.js", "Express", "NestJS", "Spring", "Django", "Flask", "Python", "C#", "Go", "Rust", "PHP", "Ruby", "HTML", "CSS", "Tailwind", "Bootstrap", "SASS", "GraphQL", "REST API", "SQL", "NoSQL", "MongoDB", "PostgreSQL", "MySQL", "AWS", "Azure", "GCP", "Docker", "Kubernetes", "CI/CD", "Git", "GitHub", "GitLab", "Testing", "TDD", "DevOps", "Algorithm", "Data Structure", "Machine Learning", "AI", "Frontend", "Backend", "Database", "Mobile", "Web"
+  ]
 
   const handleTagToggle = (tag: string) => {
     if (tags.includes(tag)) {

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -41,6 +41,7 @@ const navigation = [
   { name: "캘린더", href: "/calendar", icon: Calendar },
   { name: "Q&A", href: "/questions", icon: MessageSquare },
   { name: "피드", href: "/feed", icon: Users },
+  { name: "모임장소", href: "/place", icon: Calendar }, // 마지막으로 이동
 ]
 
 export default function Header() {


### PR DESCRIPTION
기능 설명
- 모임장소 클릭시 모임장소 페이지로 넘어가며 지도 생성
- 지도 처음 생성위치는 현재 위치 기준으로 조회
- 강남역 처럼 검색 시 그 위치로 반경 1km표시되도록 이동
- 음식점, 카페, 편의점 등 카테고리 입력시 현재위치기준에서 마커로 표시해줌
- 강남역 + 카페 처럼 입력하면 강남역 주변 카페 마커로 표시
- 마커 클릭 시 간단한 정보 표시
- question Tag문제때문에 Q&A 페이지에서 오류 생겨서 코드 수정

## 일단 최대한 테스트하고 올리는 거긴 한데, 혹시나 오류 생기면 말씀해주시면 감사하겠습니다!