### PR TITLE
[Refactor] 채팅 조회 관련 에러해결

### DIFF
--- a/components/chat/chat-messages.tsx
+++ b/components/chat/chat-messages.tsx
@@ -39,10 +39,23 @@ export const ChatMessages: React.FC<ChatMessagesProps> = ({
   // 메시지 렌더링을 위한 메모이제이션
   const messageElements = useMemo(() => {
     return displayMessages.map((msg, index) => {
+      // senderId로 멤버 정보 찾기
       const sender = displayMemberInfos.find(m => m.memberId === msg.senderId);
-      // isMe만 사용
+      
+      // isMe 판단: sender의 me 플래그 확인
       const isMe = sender?.me === true;
-      const senderName = isMe ? "나" : sender?.nickname || "알 수 없음";
+      // 닉네임 가져오기: 내 메시지는 "나", 상대방은 닉네임 또는 "알 수 없음"
+      const senderName = isMe ? "나" : (sender?.nickname || "알 수 없음");
+      
+      // 디버깅: sender를 찾지 못한 경우 또는 닉네임이 없는 경우 로그
+      if (!sender || (!sender.nickname && !isMe)) {
+        console.warn('[chat-messages] Missing sender info', {
+          messageId: msg.id,
+          senderId: msg.senderId,
+          sender: sender ? { memberId: sender.memberId, nickname: sender.nickname, me: sender.me } : null,
+          availableMemberIds: displayMemberInfos.map(m => ({ memberId: m.memberId, nickname: m.nickname, me: m.me }))
+        });
+      }
 
       // 날짜 구분선 로직
       const currentDate = new Date(msg.createdAt);

--- a/lib/api/chat.ts
+++ b/lib/api/chat.ts
@@ -101,10 +101,19 @@ export const fetchMemberInfo = async (chatRoomId: number, memberId: number): Pro
     throw new Error('Unauthenticated');
   }
   const response: ApiResponse<any> = await api.get(`/chatrooms/${chatRoomId}/members/${memberId}`);
+  
+  // API 응답에서 memberId 또는 publicId를 확인
+  // memberId가 없으면 요청한 memberId를 사용
+  const resultMemberId = response.result.memberId ?? memberId;
+  const nickname = response.result.nickname ?? '알 수 없음';
+  const lastReadMessageTime = response.result.lastReadMessageTime || new Date(0).toISOString();
+  const me = response.result.me ?? false;
+  
   return {
-    memberId: response.result.memberId ?? 0,
-    nickname: response.result.nickname ?? '알 수 없음',
-    lastReadMessageTime: response.result.lastReadMessageTime || new Date(0).toISOString()
+    memberId: resultMemberId,
+    nickname: nickname,
+    lastReadMessageTime: lastReadMessageTime,
+    me: me
   };
 };
 

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -50,6 +50,7 @@ export interface ApiResponse<T> {
         memberId?: number; // 단일 멤버 정보 조회 시
         nickname?: string; // 단일 멤버 정보 조회 시
         lastReadMessageTime?: string; // 단일 멤버 정보 조회 시
+        me?: boolean; // 단일 멤버 정보 조회 시 (내가 본인인지 여부)
         mediaIds?: string[]; // 미디어 업로드 응답 시
     };
 }


### PR DESCRIPTION
- 채팅방 조회 시 nickname, 송수신자구분 Response값을 정상적으로 날아오지만 UI상 송수신자구분 & 닉네임 조회가 안되는 상황
- Response컬럼을 통해 날아오는 필드값을 정확히 매핑하여 해결하려고 요청